### PR TITLE
Fix unbalanced audio as described in issue #2

### DIFF
--- a/volume-change.py
+++ b/volume-change.py
@@ -24,7 +24,7 @@ vol_action = sys.argv[1]
 vol_percent_change = int(sys.argv[2])
 
 # Get the volumes for all the channels
-comm_get_volume='amixer get Master | grep -oP "\[\d*%\]" | sed s:[][%]::g'
+comm_get_volume='amixer -D pulse get Master | grep -oP "\[\d*%\]" | sed s:[][%]::g'
 vol_percentages=list(map(int, getoutput(comm_get_volume).split()))
 
 # Average them into a single value (note the +0.5 for rounding errors)


### PR DESCRIPTION
This commit fixes issue #2 

It finds the current volume level, adds/subtracts the value and applies this new volume.

This can be tested using the following script:

```bash
#!/usr/bin/env bash

# Small test script to call the python script multiple times
for run in {1..100}; do
    (./volume-change.py increase 1)&
    usleep 1000
    (./volume-change.py decrease 1)&
    usleep 1000
done

amixer get Master
echo "Are the left and right channel the same?"
wait
```