### PR TITLE
Fixing percentage bar volume level

### DIFF
--- a/volume-change.py
+++ b/volume-change.py
@@ -63,4 +63,4 @@ else:
 logo += '-symbolic'
 
 # Make the dbus method call
-interface.ShowOSD({"icon":logo, "level":vol_percentage})
+interface.ShowOSD({"icon":logo, "level":vol_percentage/100})


### PR DESCRIPTION
Solves #6 
Volume bar was not showing the right volume level. 
This pull requests implements the solution given in the issue, and solves it.